### PR TITLE
Check NF version, always run trace + timeline

### DIFF
--- a/conf/testing.config
+++ b/conf/testing.config
@@ -6,11 +6,6 @@ vim: syntax=groovy
  * --------------------------------------------------------
  */
 
-params {
-  // Need to specify this here (as well as main.nf) so that timeline and trace work below.
-  outdir = './results'
-}
-
 docker {
   enabled = true
 }
@@ -19,12 +14,4 @@ process {
   cpus = 2
   memory = 7.GB
   time = 48.h
-}
-timeline {
-  enabled = true
-  file = "${params.outdir}/NGI-ChIPseq_timeline.html"
-}
-trace {
-  enabled = true
-  file = "${params.outdir}/NGI-ChIPseq_trace.txt"
 }

--- a/conf/uppmax-devel.config
+++ b/conf/uppmax-devel.config
@@ -86,8 +86,6 @@ params {
   clusterOptions = false
   rlocation = "$HOME/R/nxtflow_libs/"
   params.saveReference = true
-  // Need to specify this here (as well as main.nf) so that timeline and trace work below.
-  outdir = './results'
   // illumina iGenomes reference file paths on UPPMAX
   genomes {
     'GRCh37'      { bwa = '/sw/data/uppnex/igenomes/Homo_sapiens/Ensembl/GRCh37/Sequence/BWAIndex/' }
@@ -113,13 +111,4 @@ params {
     'Sscrofa10.2' { bwa = '/sw/data/uppnex/igenomes/Sus_scrofa/Ensembl/Sscrofa10.2/Sequence/BWAIndex/' }
     'AGPv3'       { bwa = '/sw/data/uppnex/igenomes/Zea_mays/Ensembl/AGPv3/Sequence/BWAIndex/' }
   }
-}
-
-timeline {
-  enabled = true
-  file = "${params.outdir}/NGI-ChIPseq_timeline.html"
-}
-trace {
-  enabled = true
-  file = "${params.outdir}/NGI-ChIPseq_trace.txt"
 }

--- a/main.nf
+++ b/main.nf
@@ -22,6 +22,21 @@ vim: syntax=groovy
 // Pipeline version
 version = 1.2
 
+// Check that Nextflow version is up to date enough
+// try / throw / catch works for NF versions < 0.25 when this was implemented
+nf_required_version = '0.25.1'
+try {
+  if( ! nextflow.version.matches(">= $nf_required_version") ){
+    throw GroovyException('Nextflow version too old')
+  }
+} catch (all) {
+  log.error "====================================================\n" +
+            "  Nextflow version $nf_required_version required! You are running v$workflow.nextflow.version.\n" +
+            "  Pipeline execution will continue, but things may break.\n" +
+            "  Please run `nextflow self-update` to update Nextflow.\n" +
+            "============================================================"
+}
+
 // Configurable variables
 params.name = false
 params.project = false

--- a/main.nf
+++ b/main.nf
@@ -276,7 +276,6 @@ process bwa {
     script:
     prefix = reads[0].toString() - ~/(_1)?(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?$/
     """
-    set -o pipefail
     bwa mem -M ${index}/genome.fa $reads | samtools view -bT $index - > ${prefix}.bam
     """
 }
@@ -301,7 +300,6 @@ process samtools {
 
     script:
     """
-    set -o pipefail
     samtools sort $bam -o ${bam.baseName}.sorted.bam
     samtools index ${bam.baseName}.sorted.bam
     bedtools bamtobed -i ${bam.baseName}.sorted.bam | sort -k 1,1 -k 2,2n -k 3,3n -k 6,6 > ${bam.baseName}.sorted.bed
@@ -342,7 +340,6 @@ process picard {
         }
     }
     """
-    set -o pipefail
     java -Xmx${avail_mem}m -jar \$PICARD_HOME/picard.jar MarkDuplicates \\
         INPUT=$bam \\
         OUTPUT=${prefix}.dedup.bam \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,19 @@ profiles {
   }
 }
 
+// Capture exit codes from upstream processes when piping
+process.shell = ['/bin/bash', '-euo', 'pipefail']
+
+params.outdir = './results'
+timeline {
+  enabled = true
+  file = "${params.outdir}/NGI-ChIPseq_timeline.html"
+}
+trace {
+  enabled = true
+  file = "${params.outdir}/NGI-ChIPseq_trace.txt"
+}
+
 manifest {
   homePage = 'https://github.com/SciLifeLab/NGI-ChIPseq'
   description = 'NGI-ChIPseq is a bioinformatics best-practice analysis pipeline used for ChIP-seq (chromatin immunoprecipitation sequencing) data analysis at the National Genomics Infastructure at SciLifeLab Stockholm, Sweden.'


### PR DESCRIPTION
1. Check that the version of Nextflow is recent enough and warn if not
2. Always run timeline + trace
3. Specify the `pipefail` behaviour in the config, so that it's not required in the processes themselves.