### PR TITLE
Optional filtering blacklist regions

### DIFF
--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -24,6 +24,9 @@ process {
   $bwa{
     module = ['bioinfo-tools', 'bwa', 'samtools/1.3']
   }
+  $bedtools_intersect{
+    module = ['bioinfo-tools', 'BEDTools']
+  }
   $samtools {
     module = ['bioinfo-tools', 'samtools/1.3', 'BEDTools']
   }


### PR DESCRIPTION
Added a process to filter out reads in blacklist regions, given a parameter "blacklist" pointing to a bed file. The default option is to skip this step.

