### PR TITLE
Use Singularity instead of environment modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,3 +146,6 @@ RUN pip install MACS2
 # Install MultiQC
 ENV MULTIQC_VERSION v1.3
 RUN pip install git+git://github.com/ewels/MultiQC.git@$MULTIQC_VERSION
+
+# Create UPPMAX root directories
+RUN mkdir /pica /lupus /crex1 /crex2 /proj /scratch /sw

--- a/conf/aws.config
+++ b/conf/aws.config
@@ -14,7 +14,7 @@ docker {
 }
 
 process {
-  container = 'scilifelab/ngi-chipseq'
+  container = wf_container
   executor = 'ignite'
 }
 

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -13,7 +13,7 @@ docker {
   enabled = true
 }
 process {
-  container = 'scilifelab/ngi-chipseq'
+  container = wf_container
   executor = 'local'
   cpus = $executor.cpus
   memory = $executor.memory

--- a/conf/multiqc_config.yaml
+++ b/conf/multiqc_config.yaml
@@ -21,3 +21,6 @@ custom_data:
         headers:
             NSC: {}
             RSC: {}
+report_section_order:
+    ngi-chipseq:
+        order: -1000

--- a/conf/testing.config
+++ b/conf/testing.config
@@ -10,7 +10,7 @@ docker {
   enabled = true
 }
 process {
-  container = 'scilifelab/ngi-chipseq'
+  container = wf_container
   cpus = 2
   memory = 7.GB
   time = 48.h

--- a/conf/uppmax-modules.config
+++ b/conf/uppmax-modules.config
@@ -1,0 +1,33 @@
+/*
+vim: syntax=groovy
+-*- mode: groovy;-*-
+ * -------------------------------------------------
+ *  Nextflow config file with environment modules for UPPMAX (milou / irma)
+ * -------------------------------------------------
+ */
+
+singularity {
+  enabled = false
+}
+
+process {
+  // Environment modules and resource requirements
+  $fastqc.module = ['bioinfo-tools', 'FastQC/0.7.2']
+  $trim_galore.module = ['bioinfo-tools', 'TrimGalore/0.4.1', 'FastQC/0.7.2']
+  $bwa.module = ['bioinfo-tools', 'bwa/0.7.8', 'samtools/1.5']
+  $samtools.module = ['bioinfo-tools', 'samtools/1.5', 'BEDTools/2.26.0']
+  $bwa_unmapped.module = ['bioinfo-tools', 'samtools/1.5']
+  $picard.module = ['bioinfo-tools', 'picard/2.10.3', 'samtools/1.5', 'BEDTools/2.26.0']
+  $phantompeakqualtools.module = ['bioinfo-tools', 'R/3.2.3', 'phantompeakqualtools/1.1']
+  $deepTools.module = ['bioinfo-tools', 'deepTools/2.5.1']
+  $ngsplot.module = ['bioinfo-tools', 'samtools/1.5', 'R/3.2.3', 'ngsplot/2.61']
+  $macs.module = ['bioinfo-tools', 'MACS/2.1.0']
+  $saturation.module = ['bioinfo-tools', 'MACS/2.1.0', 'samtools/1.5']
+  $saturation_r.module = ['bioinfo-tools', 'R/3.2.3']
+  $chippeakanno.module = ['bioinfo-tools', 'R/3.2.3']
+  $get_software_versions.module = ['bioinfo-tools', 'TrimGalore/0.4.1', 'FastQC/0.7.2', 'bwa/0.7.8', 'samtools/1.5', 'BEDTools/2.26.0', 'picard/2.10.3', 'deepTools/2.5.1', 'ngsplot/2.61', 'MACS/2.1.0', 'MultiQC/1.2', 'python/2.7.6']
+  // NB: Overwrite this in a config file in the working directory (nextflow.config) or with -c
+  // if you have your own installation of MultiQC outside of the environment module system.
+  // eg: Add the line: process.$multiqc.module = []
+  $multiqc.module = ['bioinfo-tools', 'MultiQC/1.3']
+}

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -4,33 +4,18 @@ vim: syntax=groovy
  * -------------------------------------------------
  *  Nextflow config file for UPPMAX (milou / irma)
  * -------------------------------------------------
- * Imported under the default 'standard' Nextflow
+ * Imported under the 'uppmax' Nextflow
  * profile in nextflow.config
  */
+
+singularity {
+  enabled = true
+}
 
 process {
   executor = 'slurm'
   clusterOptions = { "-A $params.project ${params.clusterOptions ?: ''}" }
-
-  // Environment modules and resource requirements
-  $fastqc.module = ['bioinfo-tools', 'FastQC/0.7.2']
-  $trim_galore.module = ['bioinfo-tools', 'TrimGalore/0.4.1', 'FastQC/0.7.2']
-  $bwa.module = ['bioinfo-tools', 'bwa/0.7.8', 'samtools/1.5']
-  $samtools.module = ['bioinfo-tools', 'samtools/1.5', 'BEDTools/2.26.0']
-  $bwa_unmapped.module = ['bioinfo-tools', 'samtools/1.5']
-  $picard.module = ['bioinfo-tools', 'picard/2.10.3', 'samtools/1.5', 'BEDTools/2.26.0']
-  $phantompeakqualtools.module = ['bioinfo-tools', 'R/3.2.3', 'phantompeakqualtools/1.1']
-  $deepTools.module = ['bioinfo-tools', 'deepTools/2.5.1']
-  $ngsplot.module = ['bioinfo-tools', 'samtools/1.5', 'R/3.2.3', 'ngsplot/2.61']
-  $macs.module = ['bioinfo-tools', 'MACS/2.1.0']
-  $saturation.module = ['bioinfo-tools', 'MACS/2.1.0', 'samtools/1.5']
-  $saturation_r.module = ['bioinfo-tools', 'R/3.2.3']
-  $chippeakanno.module = ['bioinfo-tools', 'R/3.2.3']
-  $get_software_versions.module = ['bioinfo-tools', 'TrimGalore/0.4.1', 'FastQC/0.7.2', 'bwa/0.7.8', 'samtools/1.5', 'BEDTools/2.26.0', 'picard/2.10.3', 'deepTools/2.5.1', 'ngsplot/2.61', 'MACS/2.1.0', 'MultiQC/1.2', 'python/2.7.6']
-  // NB: Overwrite this in a config file in the working directory (nextflow.config) or with -c
-  // if you have your own installation of MultiQC outside of the environment module system.
-  // eg: Add the line: process.$multiqc.module = []
-  $multiqc.module = ['bioinfo-tools', 'MultiQC/1.3']
+  container = "docker://$wf_container"
 }
 
 params {

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -20,7 +20,7 @@ process {
 
 params {
   clusterOptions = false
-  rlocation = "$HOME/R/nxtflow_libs/"
+  rlocation = "/usr/local/lib/R/library"
   // Max resources requested by a normal node on milou. If you need more memory, run on a fat node using:
   //   --clusterOptions "-C mem512GB" --max_memory "512GB"
   max_memory = 128.GB

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,17 +31,23 @@ See [nextflow.io](https://www.nextflow.io/) and [NGI-NextflowDocs](https://githu
 ## 2) Install the Pipeline
 This pipeline itself needs no installation - NextFlow will automatically fetch it from GitHub if `SciLifeLab/NGI-ChIPseq` is specified as the pipeline name.
 
-If you prefer, you can download the files yourself from GitHub and run them directly:
+### Offline use
+
+If you need to run the pipeline on a system with no internet connection, you will need to download the files yourself from GitHub and run them directly:
 
 ```bash
-git clone https://github.com/SciLifeLab/NGI-ChIPseq.git
-nextflow run NGI-ChIPseq/main.nf
+wget https://github.com/SciLifeLab/NGI-ChIPseq/archive/master.zip
+unzip master.zip -d /my-pipelines/
+cd /my_data/
+nextflow run /my-pipelines/NGI-ChIPseq-master
 ```
 
 ## 3.1) Configuration: UPPMAX
-By default, the pipeline is configured to run on the [Swedish UPPMAX](https://www.uppmax.uu.se/) cluster (`milou` / `irma`). As such, you shouldn't need to add any custom configuration - everything _should_ work out of the box.
+The pipeline comes bundled with configurations to use the [Swedish UPPMAX](https://www.uppmax.uu.se/) clusters (tested on `milou`, `rackham`, `bianca` and `irma`). As such, you shouldn't need to add any custom configuration - everything _should_ work out of the box.
 
-Note that you will need to specify your UPPMAX project ID when running a pipeline. To do this, use the command line flag `--project <project_ID>`. The pipeline will exit with an error message if you try to run it pipeline with the default UPPMAX config profile without a project.
+To use the pipeline on UPPMAX, you **must** specificy `-profile uppmax` when running the pipeline (as of Nov 2017).
+
+Note that you will need to specify your UPPMAX project ID when running a pipeline. To do this, use the command line flag `--project <project_ID>`. The pipeline will exit with an error message if you try to run it pipeline with the UPPMAX config profile without a project.
 
 **Optional Extra:** To avoid having to specify your project every time you run Nextflow, you can add it to your personal Nextflow config file instead. Add this line to `~/.nextflow/config`:
 
@@ -56,7 +62,7 @@ It is entirely possible to run this pipeline on other clusters, though you will 
 
 If you are the only person to be running this pipeline, you can create your config file as `~/.nextflow/config` and it will be applied every time you run Nextflow. Alternatively, save the file anywhere and reference it when running the pipeline with `-c path/to/config`.
 
-An empty configuration comes with the pipeline, which should be applied by using the command line flag `-profile none`. This prevents the UPPMAX defaults (above) from being applied and means that you only need to configure the specifics for your system.
+A basic configuration comes with the pipeline, which runs by default (the `standard` config profile with [`conf/base.config`](../conf/base.config)). This means that you only need to configure the specifics for your system and overwrite any defaults that you want to change.
 
 ### Cluster Environment
 By default, Nextflow uses the `local` executor - in other words, all jobs are run in the login session. If you're using a simple server, this may be fine. If you're using a compute cluster, this is bad as all jobs will run on the head node.
@@ -107,8 +113,38 @@ params {
 ### Software Requirements
 To run the pipeline, several software packages are required. How you satisfy these requirements is essentially up to you and depends on your system.
 
+#### Docker Image
+Docker is a software tool that allows you to run your analysis inside a "container" - basically a miniature self-contained software environment. We've already made a docker image for you, so if you can run docker and nextflow then you don't need to worry about any other software dependencies.
+
+The pipeline comes with a script to build a docker image. This runs automatically and creates a hosted docker image that you can find here: https://hub.docker.com/r/scilifelab/ngi-chipseq/
+
+If you run the pipeline with `-profile docker` or `-with-docker 'scilifelab/ngi-chipseq'` then nextflow will download this docker image automatically and run using this.
+
+Note that the docker images are tagged with version as well as the code, so this is a great way to ensure reproducibility. You can specify pipeline version when running with `-r`, for example `-r v1.4`. This uses pipeline code and docker image from this tagged version.
+
+#### Singularity image
+Many HPC environments are not able to run Docker due to problems with needing administrator privileges. [Singularity](http://singularity.lbl.gov/) is a tool designed to run on such HPC systems which is very similar to Docker. Even better, it can use create images directly from dockerhub. The UPPMAX configuration uses Singularity by default, meaning no problems with software dependencies and great reproducibility.
+
+To use the singularity image with a different config, use `-with-singularity 'docker://scilifelab/ngi-chipseq'` when running the pipeline.
+
+If you intend to run the pipeline offline, nextflow will not be able to automatically download the singularity image for you. Instead, you'll have to do this yourself manually first, transfer the image file and then point to that.
+
+First, pull the image file where you have an internet connection:
+
+```bash
+singularity pull --name ngi-chipseq.img docker://scilifelab/ngi-chipseq
+```
+
+Then transfer this file and run the pipeline with this path:
+
+```bash
+nextflow run /path/to/NGI-ChIPseq -with-singularity /path/to/ngi-chipseq.img
+```
+
 #### Environment Modules
-If your cluster uses environment modules, the software may already be available. If so, just add lines to your custom config file as follows _(customise module names and versions as appropriate)_:
+If your cluster uses environment modules, you can use the pipeline with these. There is a bundled config file to use these on UPPMAX (as was done in earlier versions of this pipeline). To use this, run the pipeline with `-profile uppmax_modules`.
+
+If running on another system, add lines to your custom config file as follows _(customise module names and versions as appropriate)_:
 
 ```groovy
 process {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,20 @@ results         # Finished results (configurable, see below)
 # Other nextflow hidden files, eg. history of pipeline runs and old logs.
 ```
 
+### Updating the pipeline
+When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:
+
+```bash
+nextflow pull scilifelab/ngi-chipseq
+```
+
+### Reproducibility
+It's a good idea to specify a pipeline version when running the pipeline on your data. This ensures that a specific version of the pipeline code and software are used when you run your pipeline. If you keep using the same tag, you'll be running the same version of the pipeline, even if there have been changes to the code since.
+
+First, go to the [NGI-ChIPseq releases page](https://github.com/SciLifeLab/NGI-ChIPseq/releases) and find the latest version number - numeric only (eg. `1.4`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.4`.
+
+This version number will be logged in reports when you run the pipeline, so that you'll know what you used when youook back in the future.
+
 ## Input Data
 
 ### `--reads`

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,17 +10,35 @@ vim: syntax=groovy
  * name here.
  */
 
-//Placeholder for Igenomes
-params.igenomes_base = "./iGenomes"
+
+// Variable to specify the docker / singularity image tag to use
+// Picks up on use of -r 1.3 in nextflow command
+container_tag = workflow.revision ? workflow.revision : 'latest'
+wf_container = "scilifelab/ngi-chipseq:${container_tag}"
+
+// Global default params, used in configs
+params {
+    outdir = './results'
+    igenomes_base = "./iGenomes"
+}
 
 profiles {
 
   standard {
     includeConfig 'conf/base.config'
+  }
+  uppmax {
+    includeConfig 'conf/base.config'
     includeConfig 'conf/uppmax.config'
     includeConfig 'conf/igenomes.config'
   }
-  devel {
+  uppmax_modules {
+    includeConfig 'conf/base.config'
+    includeConfig 'conf/uppmax.config'
+    includeConfig 'conf/uppmax-modules.config'
+    includeConfig 'conf/igenomes.config'
+  }
+  uppmax_devel {
     includeConfig 'conf/base.config'
     includeConfig 'conf/uppmax.config'
     includeConfig 'conf/uppmax-devel.config'
@@ -46,7 +64,6 @@ profiles {
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 
-params.outdir = './results'
 timeline {
   enabled = true
   file = "${params.outdir}/NGI-ChIPseq_timeline.html"

--- a/tests/uppmax_test.sh
+++ b/tests/uppmax_test.sh
@@ -33,9 +33,8 @@ fi
 
 run_name="Test UPPMAX ChIP-Seq Run: "$(date +%s)
 
-nf_cmd="nextflow run $script_path -resume -name \"$run_name\" -profile devel --genome EF2 --macsconfig ${data_dir}/macsconfig.txt --reads \"${data_dir}/*_R{1,2}.fastq.gz\""
+nf_cmd="nextflow run $script_path -resume -name \"$run_name\" -profile uppmax_devel --genome EF2 --macsconfig ${data_dir}/macsconfig.txt --reads \"${data_dir}/*_R{1,2}.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $nf_cmd
 echo "-----"
 eval $nf_cmd
-


### PR DESCRIPTION
New support for Singularity on UPPMAX!

Note that this PR contains changes to the Docker image which are required for Singularity to work. These changes won't be applied to `scilifelab/ngi-chipseq` until the PR is merged, so testing it won't work.

To test, you need to override which docker container is used for singularity, instead using my version which is up to date with this PR. To do this, use the additional nextflow flag `-with-singularity "docker://ewels/ngi-chipseq"`

Please test lots! This is quite a big change, lots of potential for breaking stuff.

Phil