### PR TITLE
Remove subpaths from docker mkdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,4 +148,4 @@ RUN pip install git+git://github.com/ewels/MultiQC.git@$MULTIQC_VERSION
 
 # Create root directories for UPPMAX and c3se hebbe
 RUN mkdir /pica /lupus /crex1 /crex2 /proj /scratch /sw \
-          /c3se /local /apps /usr/share/lmod/lmod /var/hasplm
+          /c3se /local /apps


### PR DESCRIPTION
I broke the docker build in the last PR by accident, sorry!